### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -423,6 +423,7 @@ endif::[]
 ifdef::cloud-hosted[]
 ```bash
 cd /home/project/guide-graphql-client/start/query
+export TESTCONTAINERS_RYUK_DISABLED=true
 mvn verify
 ```
 endif::[]


### PR DESCRIPTION
requires `export TESTCONTAINERS_RYUK_DISABLED=true` when run `mvn verify` on cloud-hosted env